### PR TITLE
Fix the bug that Getting unserialized object from cache when using `Trigger::getCurrent()`

### DIFF
--- a/src/Trigger.php
+++ b/src/Trigger.php
@@ -197,7 +197,13 @@ class Trigger
      */
     public function getCurrent(): ?BinLogCurrent
     {
-        return with($this->cache->get($this->replicationCacheKey));
+        return with($this->cache->get($this->replicationCacheKey), function ($cache) {
+            if (! $cache) {
+                return null;
+            }
+
+            return unserialize($cache) ?: null;
+        });
     }
 
     /**


### PR DESCRIPTION
fix #5 