### PR TITLE
Some adjustments to make version 6 work

### DIFF
--- a/src/Console/StartCommand.php
+++ b/src/Console/StartCommand.php
@@ -72,7 +72,7 @@ class StartCommand extends Command
 
                 $this->info('Subscribers');
                 $this->table(
-                    ['Subscriber', 'Registerd'],
+                    ['Subscriber', 'Registered'],
                     collect($trigger->getSubscribers())
                         ->transform(fn ($subscriber) => [$subscriber, '√'])
                 );

--- a/src/Facades/Trigger.php
+++ b/src/Facades/Trigger.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 namespace Huangdijia\Trigger\Facades;
 
 use Illuminate\Support\Facades\Facade;
+use MySQLReplication\BinLog\BinLogCurrent;
+use MySQLReplication\Event\DTO\EventDTO;
 
 /**
  * @see \Huangdijia\Trigger\Manager

--- a/src/Trigger.php
+++ b/src/Trigger.php
@@ -180,7 +180,7 @@ class Trigger
      */
     public function heartbeat(EventDTO $event): void
     {
-        $this->rememberCurrent($event->getEventInfo()->getBinLogCurrent());
+        $this->rememberCurrent($event->getEventInfo()->binLogCurrent);
     }
 
     /**


### PR DESCRIPTION
The only critical thing found so far was:

getBinLogCurrent() method has changed into property binLogCurrent.

Worth noting to users of this library is that the format when listening to events like UpdateRowsDTO has changed.

Before I received values like this:

```
        $updatedRows    = $event->getValues();
        $tableName      = $event->getTableMap()->getTable();
        $eventTimestamp = $event->getEventInfo()->getTimestamp();
```


Now I had to to change in my application into:

```
        $updatedRows    = $event->values;
        $tableName      = $event->tableMap->table;
        $eventTimestamp = $event->getEventInfo()->timestamp;
```


For bigger applications and uses there is probably a lot more affected areas so v6 has breaking changes worth to mention in changelog when it's time to release it.