### PR TITLE
Add support for php-mysql-replication v9.0.0 + fix table-specific event routing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": "^8.2",
         "illuminate/support": "^11.0 || ^12.0",
         "illuminate/console": "^11.0 || ^12.0",
-        "krowinski/php-mysql-replication": "^8.0"
+        "krowinski/php-mysql-replication": "^8.0 || ^9.0"
     },
     "require-dev": {
         "huangdijia/php-coding-standard": "^2.1",

--- a/src/Trigger.php
+++ b/src/Trigger.php
@@ -21,6 +21,7 @@ use Illuminate\Support\Facades\Cache;
 use MySQLReplication\BinLog\BinLogCurrent;
 use MySQLReplication\Config\ConfigBuilder;
 use MySQLReplication\Event\DTO\EventDTO;
+use MySQLReplication\Event\DTO\RowsDTO;
 use MySQLReplication\MySQLReplicationFactory;
 use ReflectionException;
 use ReflectionMethod;
@@ -282,10 +283,9 @@ class Trigger
         $events = [];
         $eventType = $event->getType();
 
-        if (is_callable([$event, 'getTableMap'])) {
-            /** @var \MySQLReplication\Event\DTO\RowsDTO $event */
-            $database = $event->getTableMap()->getDatabase();
-            $table = $event->getTableMap()->getTable();
+        if ($event instanceof RowsDTO) {
+            $database = $event->tableMap->database;
+            $table = $event->tableMap->table;
             $events[] = sprintf('%s.%s.%s', $database, $table, $eventType);
             $events[] = sprintf('%s.%s.%s', $database, $table, '*');
             $events[] = sprintf('%s.%s.%s', $database, '*', $eventType);


### PR DESCRIPTION
## Summary

- Widens `krowinski/php-mysql-replication` constraint from `^8.0` to `^8.0 || ^9.0`
- Fixes a bug in `Trigger::dispatch()` where table-specific event routing never actually worked

## The bug

The `dispatch()` method checks if the event has a table map using `is_callable([$event, 'getTableMap'])`, then calls `$event->getTableMap()->getDatabase()` and `->getTable()`. The problem is these getter methods don't exist in v8.x (or v9.0.0) -- both versions use public readonly properties on `TableMap` (`->database`, `->table`).

Because `is_callable` silently returns `false`, the entire block is skipped. This means any route registered with a specific table (e.g. `$trigger->on('mydb.users', 'write', ...)`) never fires. Only wildcard routes (`*.*.*`) work.

## Fix

Replaced the broken callable check with `$event instanceof RowsDTO` and access the properties directly:

```php
// Before (broken)
if (is_callable([$event, 'getTableMap'])) {
    $database = $event->getTableMap()->getDatabase();
    $table = $event->getTableMap()->getTable();

// After (works on both v8.x and v9.0.0)
if ($event instanceof RowsDTO) {
    $database = $event->tableMap->database;
    $table = $event->tableMap->table;
```

## Why v9.0.0 works without other changes

The public API surface consumed by laravel-trigger (`EventDTO`, `RowsDTO`, `TableMap`, `ConfigBuilder`, `BinLogCurrent`, `EventSubscribers`, etc.) is identical between v8.x and v9.0.0. No other files need changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Broadened dependency compatibility to support both v8.0 and v9.0 of the replication library.

* **Refactor**
  * Improved event dispatch to access table metadata more directly for row events.

* **New Features**
  * Start-up now listens for termination signals (SIGTERM/SIGINT) and exits immediately for quicker shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->