### PR TITLE
Handle SIGTERM/SIGINT in StartCommand for graceful shutdown

### DIFF
--- a/src/Console/StartCommand.php
+++ b/src/Console/StartCommand.php
@@ -94,7 +94,7 @@ class StartCommand extends Command
             goto start;
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     /**
@@ -107,7 +107,7 @@ class StartCommand extends Command
      */
     protected function listenForSignals(): void
     {
-        if (! function_exists('pcntl_async_signals')) {
+        if (! function_exists('pcntl_async_signals') || ! function_exists('pcntl_signal')) {
             return;
         }
 

--- a/src/Console/StartCommand.php
+++ b/src/Console/StartCommand.php
@@ -34,8 +34,10 @@ class StartCommand extends Command
     /**
      * Execute the console command.
      */
-    public function handle()
+    public function handle(): int
     {
+        $this->listenForSignals();
+
         $keepUp = $this->option('reset') ? false : true;
         $trigger = Trigger::replication($this->option('replication'));
 
@@ -91,5 +93,34 @@ class StartCommand extends Command
 
             goto start;
         }
+
+        return 0;
+    }
+
+    /**
+     * Register SIGTERM/SIGINT handlers for immediate shutdown.
+     *
+     * The start() method blocks inside MySQLReplicationFactory::run() reading
+     * from a socket. Setting a flag is insufficient because the blocking read
+     * never returns to check it. We must exit directly from the signal handler,
+     * matching the pattern used by the library's own Terminate subscriber.
+     */
+    protected function listenForSignals(): void
+    {
+        if (! function_exists('pcntl_async_signals')) {
+            return;
+        }
+
+        pcntl_async_signals(true);
+
+        $handler = function (int $signal) {
+            $name = $signal === SIGTERM ? 'SIGTERM' : 'SIGINT';
+            $this->info("Received {$name}, shutting down...");
+
+            exit(0);
+        };
+
+        pcntl_signal(SIGTERM, $handler);
+        pcntl_signal(SIGINT, $handler);
     }
 }


### PR DESCRIPTION
## Problem

The `StartCommand` retry loop catches `MySQLReplicationException` and retries indefinitely via `goto`, but never checks for OS shutdown signals. When a container orchestrator (Docker, Kubernetes, Kamal) sends SIGTERM during deployment, the process ignores it and keeps retrying — preventing graceful container shutdown.

This is especially problematic for **singleton binlog listeners** where the old container must stop before the new one can connect with the same replication server_id. Without signal handling:

1. New container starts and connects to MySQL binlog
2. MySQL kicks the old connection (same server_id)
3. Old container catches the exception and retries → kicks new container
4. Both containers enter an infinite "Retry now" loop
5. \`docker stop\` sends SIGTERM but the process never exits (eventually SIGKILL after timeout)

## Solution

Register \`SIGTERM\`/\`SIGINT\` handlers via \`pcntl_async_signals(true)\` that call \`exit(0)\` directly from the signal handler.

**Why \`exit()\` instead of a flag?** The \`start()\` method blocks inside \`MySQLReplicationFactory::run()\` reading from a socket. A flag-based approach is insufficient because the blocking read never returns to check it. The signal handler must terminate the process directly — this matches the pattern used by the library's own \`Terminate\` subscriber (\`src/Subscribers/Terminate.php\`).

**Why \`exit(0)\` instead of 128+signal?** The 128+N convention is for *shells* reporting how a child process died from an *unhandled* signal. When a process *handles* a signal and shuts down cleanly, \`exit(0)\` is correct — it tells Docker/Kubernetes \"I'm done, no error\" which is the desired behavior for graceful shutdown.

**Graceful guard:** No-op if the \`pcntl\` extension is unavailable or if \`pcntl_signal\` is in \`disable_functions\`.

## Changes

- Added \`listenForSignals()\` method with \`exit(0)\` in handler
- Guarded on both \`pcntl_async_signals\` and \`pcntl_signal\` function existence
- Added \`int\` return type to \`handle()\`, using \`Command::SUCCESS\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved shutdown handling: the app now responds to standard termination signals (e.g., Ctrl+C/kill) and exits with a proper status code.
* **Bug Fixes**
  * Fixed cases where the process could hang during termination by ensuring immediate shutdown when a termination signal is received.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->