### PR TITLE
Add Laravel 13 support

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,7 +17,10 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [ '8.5', '8.4', '8.3', '8.2']
-        laravel: [ '12', '11' ]
+        laravel: [ '13', '12', '11' ]
+        exclude:
+          - php: '8.2'
+            laravel: '13'
       max-parallel: 26
     steps:
       - name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -15,13 +15,13 @@
     }],
     "require": {
         "php": "^8.2",
-        "illuminate/support": "^11.0 || ^12.0",
-        "illuminate/console": "^11.0 || ^12.0",
+        "illuminate/support": "^11.0 || ^12.0 || ^13.0",
+        "illuminate/console": "^11.0 || ^12.0 || ^13.0",
         "krowinski/php-mysql-replication": "^8.0 || ^9.0"
     },
     "require-dev": {
         "huangdijia/php-coding-standard": "^2.1",
-        "orchestra/testbench": "^9.0 || ^10.0",
+        "orchestra/testbench": "^9.0 || ^10.0 || ^11.0",
         "phpstan/phpstan": "2.1.x-dev"
     },
     "autoload": {


### PR DESCRIPTION
## What

- Allows `illuminate/support` and `illuminate/console` `^13.0`
- Allows `orchestra/testbench` `^11.0` for testing against Laravel 13
- Adds Laravel 13 to the CI test matrix (excluding PHP 8.2, since Laravel 13 requires PHP >= 8.3)

## Why

Laravel 13 was released in March 2026 and the package currently caps at `^12.0`, which blocks installation in upgraded applications. The package only uses `illuminate/support` and `illuminate/console` APIs that are unchanged in 13.x — we are running this change in production against Laravel 13 without issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended package compatibility to support Laravel 13 alongside existing Laravel 11 and 12 support.
  * Updated test infrastructure to validate compatibility across all supported Laravel versions, with targeted PHP version exclusions where necessary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->